### PR TITLE
Add track opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ For example, `yummy` is not valid, but `YuMmy` is valid.
 --minify,   -m           Minify output like UglifyJS
 --no-color,              Print code in a single color
 --color,    -c           Colorize parameters anyway (enabled by default)
+--no-track,              Just load, don't send a pageview
+--track,    -t           Send a pageview after loading (enabled by default)
 --help,     -h           Print usage information
 --version,  -v           Print version
 ```
@@ -231,6 +233,13 @@ Type: `Boolean`
 Default: `false`
 
 Colorize the parameters with [ANSI escape code](https://wikipedia.org/wiki/ANSI_escape_code#Colors).
+
+##### options.track
+
+Type: `Boolean`
+Default: `true`
+
+`false` excludes `create` and `send` commands after the loading code.
 
 ## License
 

--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,7 @@ var argv = require('minimist')(process.argv.slice(2), {
     w: 'double',
     m: 'minify',
     c: 'color',
+    t: 'track',
     h: 'help',
     v: 'version'
   },
@@ -39,6 +40,8 @@ if (argv.version) {
     yellow('--double,   -w         ') + '  Use double quotes (single quotes by default)',
     yellow('--no-color,            ') + '  Print code in a single color',
     yellow('--color,    -c         ') + '  Colorize parameters anyway (enabled by default)',
+    yellow('--no-track,            ') + '  Just load, don\'t send a pageview',
+    yellow('--track,    -t         ') + '  Send a pageview after loading (enabled by default)',
     yellow('--help,     -h         ') + '  Print usage information',
     yellow('--version,  -v         ') + '  Print version',
     ''

--- a/dist/isogram-browser.js
+++ b/dist/isogram-browser.js
@@ -78,5 +78,9 @@ window.isogram = function isogram(characters, options) {
     return gaLoader.replace(/\n/g, '') + gaTracker;
   }
 
-  return gaLoader + '\n\n' + gaTracker;
+  if (options.track === undefined || options.track) {
+    return gaLoader + '\n\n' + gaTracker;
+  }
+
+  return gaLoader;
 };

--- a/dist/isogram-standalone.js
+++ b/dist/isogram-standalone.js
@@ -84,31 +84,59 @@ module.exports = function isogram(characters, options) {
     return gaLoader.replace(/\n/g, '') + gaTracker;
   }
 
-  return gaLoader + '\n\n' + gaTracker;
+  if (options.track === undefined || options.track) {
+    return gaLoader + '\n\n' + gaTracker;
+  }
+
+  return gaLoader;
 };
 
-},{"array-to-sentence":2,"assert-unique":3,"ga-loader-snippets":5,"ga-tracker-snippet":6,"is-var-name":7}],2:[function(require,module,exports){
+},{"array-to-sentence":3,"assert-unique":4,"ga-loader-snippets":5,"ga-tracker-snippet":6,"is-var-name":7}],2:[function(require,module,exports){
+/*!
+ * array-duplicated | MIT (c) Shinnosuke Watanabe
+ * https://github.com/shinnn/array-duplicated
+*/
+module.exports = function arrayDuplicated(arr) {
+  'use strict';
+
+  if (!Array.isArray(arr)) {
+    throw new TypeError(
+      arr +
+      ' is not an array. Argument to array-duplicated  must be an array.'
+    );
+  }
+
+  var result = [];
+  for (var i = 0; i < arr.length; i++) {
+    if (arr.indexOf(arr[i]) !== i && result.indexOf(arr[i]) === -1) {
+      result.push(arr[i]);
+    }
+  }
+
+  return result;
+};
+
+},{}],3:[function(require,module,exports){
 /*!
  * array-to-sentence | MIT (c) Shinnosuke Watanabe
  * https://github.com/shinnn/array-to-sentence
 */
-
 module.exports = function arrayToSentence(arr, options) {
   'use strict';
 
   if (!Array.isArray(arr)) {
-    throw new TypeError('First argument must be an array.');
-  }
-
-  if (arr.length === 0) {
-    return '';
+    throw new TypeError(String(arr) + ' is not an array. Expected an array .');
   }
 
   options = options || {};
 
-  function validateOption(name) {
-    if (typeof options[name] !== 'string') {
-      throw new TypeError('`' + name + '` option must be a string.');
+  function validateOption(optionName) {
+    if (typeof options[optionName] !== 'string') {
+      throw new TypeError(
+        String(options[optionName]) +
+        ' is not a string. ' +
+        '`' + optionName + '` option must be a string.'
+      );
     }
   }
 
@@ -124,14 +152,18 @@ module.exports = function arrayToSentence(arr, options) {
     validateOption('lastSeparator');
   }
 
+  if (arr.length === 0) {
+    return '';
+  }
+
   if (arr.length === 1) {
-    return arr[arr.length - 1];
+    return arr[0];
   }
 
   return arr.slice(0, -1).join(options.separator) + options.lastSeparator + arr[arr.length - 1];
 };
 
-},{}],3:[function(require,module,exports){
+},{}],4:[function(require,module,exports){
 /*!
  * assert-unique | MIT (c) Shinnosuke Watanabe
  * https://github.com/shinnn/assert-unique
@@ -177,30 +209,7 @@ module.exports = function assertUnique() {
   throw new Error(arrayToSentence(duplicates) + ' ' + aux + ' duplicated.');
 };
 
-},{"array-duplicated":4,"array-to-sentence":2}],4:[function(require,module,exports){
-/*!
- * array-duplicated | MIT (c) Shinnosuke Watanabe
- * https://github.com/shinnn/array-duplicated
-*/
-
-module.exports = function arrayDuplicated(arr) {
-  'use strict';
-
-  if (!Array.isArray(arr)) {
-    throw new TypeError('Argument must be an array.');
-  }
-
-  var result = [];
-  for (var i = 0; i < arr.length; i++) {
-    if (arr.indexOf(arr[i]) !== i && result.indexOf(arr[i]) === -1) {
-      result.push(arr[i]);
-    }
-  }
-
-  return result;
-};
-
-},{}],5:[function(require,module,exports){
+},{"array-duplicated":2,"array-to-sentence":3}],5:[function(require,module,exports){
 /*!
  * HTML5 Boilerplate | MIT (c) HTML5 Boilerplate
  * https://github.com/h5bp/html5-boilerplate

--- a/index.js
+++ b/index.js
@@ -83,5 +83,9 @@ module.exports = function isogram(characters, options) {
     return gaLoader.replace(/\n/g, '') + gaTracker;
   }
 
-  return gaLoader + '\n\n' + gaTracker;
+  if (options.track === undefined || options.track) {
+    return gaLoader + '\n\n' + gaTracker;
+  }
+
+  return gaLoader;
 };

--- a/test-api.js
+++ b/test-api.js
@@ -11,7 +11,7 @@ var gaTrackerSnippet = require('ga-tracker-snippet');
 
 function runTest(description, isogram) {
   test(description, function(t) {
-    t.plan(26);
+    t.plan(27);
 
     t.equal(isogram.name, 'isogram', 'should have a function name.');
 
@@ -98,6 +98,14 @@ function runTest(description, isogram) {
       isogram({singleQuotes: false}),
       isogram(null).replace(/'/g, '\"'),
       'should replace all the single quotes with double quotes, using `minify` option.'
+    );
+
+    t.ok(
+      scriptEqual(
+        isogram({track: false}),
+        gaLoaderSnippets.with6params
+      ),
+      'should not include the tracker snippet if `track` option is false.'
     );
 
     t.throws(

--- a/test-cli.js
+++ b/test-cli.js
@@ -13,7 +13,7 @@ var isogram = require('./');
 var bin = 'node ' + pkg.bin + ' ';
 
 test('"isogram" command', function(t) {
-  t.plan(19);
+  t.plan(20);
 
   exec(bin, function(err, stdout, stderr) {
     t.deepEqual(
@@ -53,6 +53,14 @@ test('"isogram" command', function(t) {
       [err, stdout, stderr],
       [null, isogram({color: false}) + '\n', ''],
       'should omit ANSI colors from the result, using --no-color flag.'
+    );
+  });
+
+  exec(bin + '--no-track', function(err, stdout, stderr) {
+    t.deepEqual(
+      [err, stdout, stderr],
+      [null, isogram({track: false}) + '\n', ''],
+      'should omit `create` and `send` commands if using --no-track flag.'
     );
   });
 


### PR DESCRIPTION
Add an option to allow loading ga without sending a pageview immediately.

I needed this when dynamically generating a ga loader module in a webpack build. The code already sent pageview commands elsewhere, so didn't need the create/pageview in the (generated) loader module.